### PR TITLE
Fixed electron-builder crash because of missing field

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/GitSquared/edex-ui.git"
   },
-  "author": "GitSquared",
+  "author": "GitSquared <squared@codebrew.fr>",
   "license": "GPL-3.0",
   "bugs": {
     "url": "https://github.com/GitSquared/edex-ui/issues"


### PR DESCRIPTION
Filled the mail field to allow `electron-builder` to build a pacman package.