### PR TITLE
Added theme without keyboard

### DIFF
--- a/src/assets/themes/tron-notype.json
+++ b/src/assets/themes/tron-notype.json
@@ -1,0 +1,30 @@
+{
+    "colors": {
+        "r": 170,
+        "g": 207,
+        "b": 209,
+        "black": "#000000",
+        "light_black": "#05080d",
+        "grey": "#262828"
+    },
+    "cssvars": {
+        "font_main": "United Sans Medium",
+        "font_main_light": "United Sans Light"
+    },
+    "terminal": {
+        "fontFamily": "Fira Mono",
+        "cursorStyle": "block",
+        "foreground": "#aacfd1",
+        "background": "#05080d",
+        "cursor": "#aacfd1",
+        "cursorAccent": "#aacfd1",
+        "selection": "rgba(170,207,209,0.3)"
+    },
+    "globe": {
+        "base": "#000000",
+        "marker": "#aacfd1",
+        "pin": "#aacfd1",
+        "satellite": "#aacfd1"
+    },
+    "injectCSS": "section#filesystem{left: 0;width:100vw} section#filesystem>h3.title, section#filesystem>div{width:100vw} section#keyboard{display:none;}"
+}


### PR DESCRIPTION
Solves the problem behind issue #259 

There is now a theme named `tron-notype` that has no keyboard and also has a larger filesystem pane. Change it to your default theme by editing [userData](https://github.com/GitSquared/edex-ui/wiki/userData)/settings.json and changing `"theme":"tron"` to `"theme":"tron-notype"`.