### PR TITLE
Let arch-like(manjaro) users enjoy greeting too

### DIFF
--- a/src/_renderer.js
+++ b/src/_renderer.js
@@ -94,7 +94,7 @@ function displayLine() {
     function isArchUser() {
         return require("os").platform() === "linux"
                 && fs.existsSync("/etc/os-release")
-                && fs.readFileSync("/etc/os-release").toString().includes("archlinux");
+                && fs.readFileSync("/etc/os-release").toString().includes("arch");
     }
 
     if (log[i] === undefined) {


### PR DESCRIPTION
* archlinux:
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
ID_LIKE=archlinux
ANSI_COLOR="0;36"
HOME_URL="https://www.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://bugs.archlinux.org/"

* manjaro:
NAME="Manjaro Linux"
ID=manjaro
ID_LIKE=arch
PRETTY_NAME="Manjaro Linux"
ANSI_COLOR="1;32"
HOME_URL="https://www.manjaro.org/"
SUPPORT_URL="https://www.manjaro.org/"
BUG_REPORT_URL="https://bugs.manjaro.org/"

Change archlinux to arch make other archlinux-like users see the greeting too