### PR TITLE
Ignore JetBrains project folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ jspm_packages
 # Optional REPL history
 .node_repl_history
 
+# JetBrains IDE project folder (e.g. WebStorm)
+.idea
+
 settings.json
 dist
 prebuild-src


### PR DESCRIPTION
I use WebStorm for development and it creates this folder for project settings and stuff. You can be more granular with how you choose to ignore files from this folder (see [this StackOverflow post](https://stackoverflow.com/questions/11968531/what-to-gitignore-from-the-idea-folder)) but I think it's probably overkill -- I don't really want to clutter up the repository unless other people start developing on this using JetBrains IDEs.