### PR TITLE
fix index out of bounds issue

### DIFF
--- a/src/classes/keyboard.class.js
+++ b/src/classes/keyboard.class.js
@@ -35,10 +35,8 @@ class Keyboard {
                 }
 
                 Object.keys(keyObj).forEach((property) => {
-                    let i = 1;
-                    while(i <= ctrlseq.length) {
+                    for (let i = 1; i < ctrlseq.length; i++) {
                         keyObj[property] = keyObj[property].replace("~~~CTRLSEQ"+i+"~~~", ctrlseq[i]);
-                        i++;
                     }
                     if (property.endsWith("cmd")) {
                         key.dataset[property] = keyObj[property];


### PR DESCRIPTION
This fixes an off-by-one comparison against the length of the array being iterated over. I found this loop condition error on the [list of alerts for this project](https://lgtm.com/projects/g/GitSquared/edex-ui/alerts) on LGTM. (there are a couple of other alerts that would probably be good to look at too!)

*(Full disclosure: I'm part of the team behind LGTM.com)*



