### PR TITLE
Tracking is working under windows cmd

### DIFF
--- a/src/classes/terminal.class.js
+++ b/src/classes/terminal.class.js
@@ -270,6 +270,35 @@ class Terminal {
                                 }
                             });
                             break;
+                        case "Windows_NT":
+                            const execFile  = require('child_process').execFile;
+                            const path = require('path');
+                            // I dont know how to resolve path so here is the bad way to do that
+                            // if in .asar then go to .asar.unpacked (.exe wont be executed from .asar file)
+                            let exePath = require.resolve('windows-tlist/tlist.exe');
+                            // const asarPath = path.normalize(path.join(exePath, '..', '..', '..'))
+                            // if (asarPath.endsWith(".asar")) {
+                            //     exePath = asarPath + ".unpacked/node_modules/windows-tlist/tlist.exe";
+                            // } else {
+                            //     exePath = require.resolve('windows-tlist/tlist.exe');
+                            // }
+                            execFile(exePath, [`"${pid}"`], (e, stdout, stderr)=> {
+                            // exec('"' + exePath + '" "' + pid + '"', (e, stdout, stderr)=> {
+                                if (e !== null) {
+                                    reject(e);
+                                } else {
+                                    const re = /^\s*CWD\s*:\s*(.*?)\s*$/gim;
+                                    const match = re.exec(stdout);
+                                    if (match && match[1]) {
+                                        console.log(match[1])
+                                        resolve(match[1]);
+                                    } else {
+                                        console.log(stdout)
+                                        reject("No match");
+                                    }
+                                }
+                            });
+                            break;
                         default:
                             reject("Unsupported OS");
                     }

--- a/src/classes/terminal.class.js
+++ b/src/classes/terminal.class.js
@@ -272,7 +272,13 @@ class Terminal {
                             break;
                         case "Windows_NT":
                             // checking cwd using tlist from npm, sadly  for powershell it will always say the starting path
-                            let exePath = require.resolve('windows-tlist/tlist.exe');
+                            let exePath;
+                            // windows-tlist is optional dependency so we must check if it's included
+                            try {
+                                exePath = require.resolve('windows-tlist/tlist.exe');
+                            } catch (e) {
+                                reject("Tlist dependency is not found");
+                            }
                             // must be execFile not exec otherwise will not work in .asar
                             require('child_process').execFile(exePath, [`${pid}`], (e, stdout, stderr)=> {
                                 if (e !== null) {

--- a/src/classes/terminal.class.js
+++ b/src/classes/terminal.class.js
@@ -271,30 +271,19 @@ class Terminal {
                             });
                             break;
                         case "Windows_NT":
-                            const execFile  = require('child_process').execFile;
-                            const path = require('path');
-                            // I dont know how to resolve path so here is the bad way to do that
-                            // if in .asar then go to .asar.unpacked (.exe wont be executed from .asar file)
+                            // checking cwd using tlist from npm, sadly  for powershell it will always say the starting path
                             let exePath = require.resolve('windows-tlist/tlist.exe');
-                            // const asarPath = path.normalize(path.join(exePath, '..', '..', '..'))
-                            // if (asarPath.endsWith(".asar")) {
-                            //     exePath = asarPath + ".unpacked/node_modules/windows-tlist/tlist.exe";
-                            // } else {
-                            //     exePath = require.resolve('windows-tlist/tlist.exe');
-                            // }
-                            execFile(exePath, [`"${pid}"`], (e, stdout, stderr)=> {
-                            // exec('"' + exePath + '" "' + pid + '"', (e, stdout, stderr)=> {
+                            // must be execFile not exec otherwise will not work in .asar
+                            require('child_process').execFile(exePath, [`${pid}`], (e, stdout, stderr)=> {
                                 if (e !== null) {
                                     reject(e);
                                 } else {
                                     const re = /^\s*CWD\s*:\s*(.*?)\s*$/gim;
                                     const match = re.exec(stdout);
                                     if (match && match[1]) {
-                                        console.log(match[1])
                                         resolve(match[1]);
                                     } else {
-                                        console.log(stdout)
-                                        reject("No match");
+                                        reject("Task list doesn't contain process cwd");
                                     }
                                 }
                             });

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -481,7 +481,8 @@
     "windows-tlist": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/windows-tlist/-/windows-tlist-0.1.3.tgz",
-      "integrity": "sha1-qYwfHwwYBtlgE3Y9LgQ4MX1H1ks="
+      "integrity": "sha1-qYwfHwwYBtlgE3Y9LgQ4MX1H1ks=",
+      "optional": true
     },
     "wrappy": {
       "version": "1.0.2",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -478,6 +478,11 @@
         "isexe": "^2.0.0"
       }
     },
+    "windows-tlist": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/windows-tlist/-/windows-tlist-0.1.3.tgz",
+      "integrity": "sha1-qYwfHwwYBtlgE3Y9LgQ4MX1H1ks="
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -34,11 +34,11 @@
     "smoothie": "1.35.0",
     "systeminformation": "4.1.1",
     "tail": "2.0.2",
-    "windows-tlist": "^0.1.3",
     "ws": "6.2.0",
     "xterm": "3.12.0"
   },
   "optionalDependencies": {
-    "osx-temperature-sensor": "1.0.3"
+    "osx-temperature-sensor": "1.0.3",
+    "windows-tlist": "^0.1.3"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -34,6 +34,7 @@
     "smoothie": "1.35.0",
     "systeminformation": "4.1.1",
     "tail": "2.0.2",
+    "windows-tlist": "^0.1.3",
     "ws": "6.2.0",
     "xterm": "3.12.0"
   },


### PR DESCRIPTION
Tracking under windows is done with tlist dependency. Does not work with powershell (it keeps its 'location' separated from constant 'cwd')