### PR TITLE
Fix media with hashtags in their filenames

### DIFF
--- a/src/_renderer.js
+++ b/src/_renderer.js
@@ -13,6 +13,9 @@ window._escapeHtml = text => {
     };
     return text.replace(/[&<>"']/g, m => {return map[m];});
 };
+window._encodePathURI = uri => {
+    return encodeURI(uri).replace(/#/g, "%23");
+};
 window._purifyCSS = str => {
     if (typeof str === "undefined") return "";
     if (typeof str !== "string") {

--- a/src/classes/filesystem.class.js
+++ b/src/classes/filesystem.class.js
@@ -548,11 +548,11 @@ class FilesystemDisplay {
 
             switch(type || block.type) {
                 case "image":
-                    html = `<img class="fsDisp_mediaDisp" src="${path || block.path}" ondragstart="return false;">`;
+                    html = `<img class="fsDisp_mediaDisp" src="${window._encodePathURI(path || block.path)}" ondragstart="return false;">`;
                     break;
                 case "video":
                     html = `<video class="fsDisp_mediaDisp" controls preload="auto">
-                            <source src="${path || block.path}">
+                            <source src="${window._encodePathURI(path || block.path)}">
                             Unsupported video format!
                         </video>`;
                     break;


### PR DESCRIPTION
For example, and image titled "abc #abc abc.jpg" will not load, as the browser will interpret # as an anchor point instead.