### PR TITLE
Fix issue where images wouldn't load from general filesystem on Windows

### DIFF
--- a/src/classes/filesystem.class.js
+++ b/src/classes/filesystem.class.js
@@ -542,16 +542,13 @@ class FilesystemDisplay {
 
         this.openMedia = (name, path, type) => {
             let block, html;
-            
-            console.log(name + " : " + path)
 
             if (typeof name === "number") {
                 block = this.cwd[name];
                 name = block.name;
             }
 
-            let temp = block.path.replace(/\\/g, "/");
-            block.path = temp;
+            block.path = block.path.replace(/\\/g, "/"); 
 
             switch(type || block.type) {
                 case "image":

--- a/src/classes/filesystem.class.js
+++ b/src/classes/filesystem.class.js
@@ -542,11 +542,16 @@ class FilesystemDisplay {
 
         this.openMedia = (name, path, type) => {
             let block, html;
+            
+            console.log(name + " : " + path)
 
             if (typeof name === "number") {
                 block = this.cwd[name];
                 name = block.name;
             }
+
+            let temp = block.path.replace(/\\/g, "/");
+            block.path = temp;
 
             switch(type || block.type) {
                 case "image":


### PR DESCRIPTION
I found an issue while poking about the master branch on Windows where if you click an image in the filesystem, the image wouldn't load. It came up with an error in the dev console that looked something like this:

```
/C:/%5CUsers%5CSurge%5CDesktop%5Cwofrpg-site-NEW%5Cmain%5Cimages%5Cicon.png:1 GET file:///C:/%5CUsers%5CSurge%5CDesktop%5Cwofrpg-site-NEW%5Cmain%5Cimages%5Cicon.png net::ERR_FAILED
Image (async)
Modal @ modal.class.js:90
FilesystemDisplay.openMedia @ filesystem.class.js:570
onclick @ ui.html:1
```

I fixed the issue by adding a line in the `openMedia` function of the filesystem class that replaces all backslashes with forward slashes. It could definitely be done a lot better, but this does work without any issues.