### PR TITLE
Implement a text editor feature

### DIFF
--- a/src/_renderer.js
+++ b/src/_renderer.js
@@ -807,6 +807,12 @@ window.openSettings = async () => {
     });
 };
 
+window.writeFile = (path) => {
+    fs.writeFile(path, document.getElementById("fileEdit").value, "utf-8", () => {
+        document.getElementById("fedit-status").innerHTML = "<i>File saved.</i>";
+    });
+}
+
 window.writeSettingsFile = () => {
     window.settings = {
         shell: document.getElementById("settingsEditor-shell").value,

--- a/src/assets/css/modal.css
+++ b/src/assets/css/modal.css
@@ -144,6 +144,19 @@ div.modal_popup table:not(#settingsEditor) td:first-child {
     text-align: center;
 }
 
+div.modal_popup textarea {
+    background: var(--color_light_black);
+    color: rgb(var(--color_r), var(--color_g), var(--color_b));
+    border: 0.15vh solid rgb(var(--color_r), var(--color_g), var(--color_b));
+    padding: 0.4vh 0.2vh;
+    font-size: 1.4vh;
+    resize: none;
+}
+
+div.modal_popup textarea:active, div.modal_popup textarea:focus {
+    outline: none !important;
+}
+
 div.modal_popup td input {
     width: 100%;
     background: var(--color_light_black);

--- a/src/classes/filesystem.class.js
+++ b/src/classes/filesystem.class.js
@@ -361,10 +361,10 @@ class FilesystemDisplay {
                 }
 
                 if (e.type === "edex-theme") {
-                    cmd = `window.themeChanger('${e.name.slice(0, -5)}')`;
+                    cmd = `window.themeChanger("${e.name.slice(0, -5)}")`;
                 }
                 if (e.type === "edex-kblayout") {
-                    cmd = `window.remakeKeyboard('${e.name.slice(0, -5)}')`;
+                    cmd = `window.remakeKeyboard("${e.name.slice(0, -5)}")`;
                 }
                 if (e.type === "edex-settings") {
                     cmd = `window.openSettings()`;

--- a/src/classes/filesystem.class.js
+++ b/src/classes/filesystem.class.js
@@ -344,6 +344,10 @@ class FilesystemDisplay {
                     }
                 }
 
+                if (e.type === "file") {
+                    cmd = `window.fsDisp.openFile(${blockIndex})`
+                }
+
                 if (e.type === "system") {
                     cmd = "";
                 }
@@ -538,6 +542,65 @@ class FilesystemDisplay {
         // See #392
         if (window.performance.navigation.type === 0) {
             this.readFS(window.term[window.currentTerm].cwd || window.settings.cwd);
+        }
+
+        this.openFile = (name, path, type) => { //Might add text formatting at some point, not now though - Surge
+            let block;
+
+            if (typeof name === "number") {
+                block = this.cwd[name];
+                name = block.name
+            }
+
+            block.path = block.path.replace(/\\/g, "/");
+
+            let filetype = name.split(".")[name.split(".").length - 1];
+            switch (filetype) {
+                case "xml":
+                case "yaml":
+                case "java":
+                case "cs":
+                case "cpp":
+                case "h":
+                case "html":
+                case "css":
+                case "js":
+                case "md":
+                case "log":
+                case "bat":
+                case "sh":
+                case "gd":
+                //To anyone else working with this: Feel free to add on to this list. - Surge
+                case "txt":
+                case "json":
+                    fs.readFile(block.path, 'utf-8', (err, data) => {
+                        if (err) {
+                            new Modal({
+                                type: "info",
+                                title: "Failed to load file: " + block.path,
+                                html: err
+                            });
+                            console.log(err);
+                        };
+                        window.keyboard.detach();
+                        new Modal(
+                            {
+                                type: "custom",
+                                title: _escapeHtml(name),
+                                html: `<textarea id="fileEdit" rows="40" cols="150" spellcheck="false">${data}</textarea><p id="fedit-status"></p>`,
+                                buttons: [
+                                    {label:"Save to Disk",action:`window.writeFile('${block.path}')`}
+                                ]
+                            }, () => {
+                                window.keyboard.attach();
+                                window.term[window.currentTerm].term.focus();
+                            }
+                        );
+                    });
+                    break;
+                default:
+                    return;
+            }
         }
 
         this.openMedia = (name, path, type) => {


### PR DESCRIPTION
Not sure if this would be useful or not, but I added a text editor that you can use through the file system. You can click a file in the file explorer and it will open a popup that displays the filename (and extension), and the content of the file that's currently there. I've provided screenshots as well.

![Capture](https://user-images.githubusercontent.com/22083792/98591674-8ebf2200-229e-11eb-8a0e-6d1b08f72c7f.PNG)
Open in the tron-disrupted theme

![Capture2](https://user-images.githubusercontent.com/22083792/98591711-9f6f9800-229e-11eb-903c-913ed4c3a195.PNG)
Open in the red theme

Right now, the only kinds of files that can be opened are HTML, CSS, Javascript, XML, Yaml, Java, C#, C++ and H, Markdown, Batch and Shell, GDscript ([godot engine](https://godotengine.org/)), JSON (excludes the themes, keyboards, settings.json, and shortcuts.json), plain text, and log files, though that list can be expanded as needed.

In the future, I might try to make the different file types able to be differentiated by their icons, though that's a project for another day. I might also have the text inside the `textarea` a little bigger, and maybe always white, because the red theme is really hard to read from the default monospace font. Lmk if I need to make any changes