### PR TITLE
Fixed issue #758

### DIFF
--- a/src/classes/filesystem.class.js
+++ b/src/classes/filesystem.class.js
@@ -123,8 +123,10 @@ class FilesystemDisplay {
             if (this._fsWatcher) {
                 this._fsWatcher.close();
             }
-            this._fsWatcher = fs.watch(dir, () => {
-                this._runNextTick = true;
+            this._fsWatcher = fs.watch(dir, (eventType, filename) => {
+                if (eventType != "change") { // #758 - Don't refresh file view if only file contents have changed.
+                    this._runNextTick = true;
+                }
             });
         };
 


### PR DESCRIPTION
#758 - Don't refresh file view if only file contents have changed.
On my machine, I observed the view constantly refreshing when in my home directory.  This was due to a file being frequently updated (.xsession-errors).  Each time this file was updated, the fw.watch callback was triggered and the view was refreshed.