### PR TITLE
Fix issue #873

### DIFF
--- a/src/classes/terminal.class.js
+++ b/src/classes/terminal.class.js
@@ -439,7 +439,11 @@ class Terminal {
                     case "Resize":
                         let cols = args[1];
                         let rows = args[2];
-                        this.tty.resize(Number(cols), Number(rows));
+                        try {
+                            this.tty.resize(Number(cols), Number(rows));
+                        } catch (error) {
+                            //Keep going, it'll work anyways.
+                        }
                         this.onresized(cols, rows);
                         break;
                     default:


### PR DESCRIPTION
The issue described a crash when opening a previously closed tty instance. The issue appeared to be windows specific, as when I tested this on my raspberry pi the issue did not occur. All I did was add a try catch block where the terminal gets resized and ignore the error, which appeared to fix the issue.