### PR TITLE
Set Appimage compression rate to `normal`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "appId": "com.edex.ui",
     "productName": "eDEX-UI",
     "asar": true,
-    "compression": "maximum",
+    "compression": "normal",
     "copyright": "Copyright © 2017-2020 Gabriel 'Squared' SAILLARD <gabriel@saillard.dev> (https://gaby.dev)",
     "directories": {
       "output": "dist",


### PR DESCRIPTION
Appimage construction used to compress files aggressively. Using roughly no compression reduces the start time by ~90%.

Closes #893