### PR TITLE
Fix issue #833

### DIFF
--- a/src/classes/sysinfo.class.js
+++ b/src/classes/sysinfo.class.js
@@ -122,7 +122,7 @@ class Sysinfo {
             if (bat.hasbattery) {
                 if (bat.ischarging) {
                     indicator.innerHTML = "CHARGE";
-                } else if (bat.acconnected || bat.timeremaining === -1) {
+                } else if (bat.acconnected /*|| bat.timeremaining === -1*/) {//fixes #833
                     indicator.innerHTML = "WIRED";
                 } else {
                     indicator.innerHTML = bat.percent+"%";


### PR DESCRIPTION
Removes code `|| bat.timeremaining === -1` due to causing issues with the battery, fixes #833 