### PR TITLE
Improvements on process list modal

### DIFF
--- a/src/assets/css/mod_processlist.css
+++ b/src/assets/css/mod_processlist.css
@@ -11,6 +11,10 @@ table#processContainer td.header {
     text-align: center;
 }
 
+table#processContainer td.header:hover {
+    cursor: pointer;
+}
+
 table#processContainer td.pid {
     width: 5vw;
 }

--- a/src/classes/toplist.class.js
+++ b/src/classes/toplist.class.js
@@ -52,6 +52,40 @@ class Toplist {
     }
 
     processList(){
+<<<<<<< HEAD
+=======
+        let sortKey = "runtime";
+        let ascending = false;
+
+        function setSortKey(fieldName){
+            if (sortKey === fieldName){
+                ascending = !ascending;
+            }
+            else {
+                sortKey = fieldName;
+                ascending = false;
+            }
+        }
+
+        function formatRuntime(ms){
+            const msInDay = 24 * 60 * 60 * 1000;
+            let days = Math.floor(ms / msInDay);
+            let remainingMS = ms % msInDay;
+
+            const msInHour = 60 * 60 * 1000;
+            let hours = Math.floor(remainingMS / msInHour);
+            remainingMS = ms % msInHour;
+
+            let msInMin = 60 * 1000;
+            let minutes = Math.floor(remainingMS / msInMin);
+            remainingMS = ms % msInMin;
+
+            let seconds = Math.floor(remainingMS / 1000);
+
+            return `${days < 10 ? "0" : ""}${days}:${hours < 10 ? "0" : ""}${hours}:${minutes < 10 ? "0" : ""}${minutes}:${seconds < 10 ? "0" : ""}${seconds}`;
+        }
+
+>>>>>>> ab1d3b29ae818a2450f52994d0a2288d2e1eb473
         function updateProcessList(){
             window.si.processes().then(data => {
                 if (window.settings.excludeThreadsFromToplist === true) {
@@ -68,16 +102,64 @@ class Toplist {
                     });
                 }
 
+                data.list.forEach(proc => {
+                    proc.runtime = new Date(Date.now() - Date.parse(proc.started));
+                });
+
                 let list = data.list.sort((a, b) => {
-                    return ((b.pcpu-a.pcpu)*100 + b.pmem-a.pmem);
-                });//.splice(0, 30);
+                    switch (sortKey) {
+                    case "PID":
+                        if (ascending) return a.pid - b.pid;
+                        else return b.pid - a.pid;
+                    case "Name":
+                        if (ascending){
+                            if (a.name > b.name) return -1;
+                            if (a.name < b.name) return 1;
+                            return 0;
+                        }
+                        else {
+                            if (a.name < b.name) return -1;
+                            if (a.name > b.name) return 1;
+                            return 0;
+                        }
+                    case "User":
+                        if (ascending){
+                            if (a.user > b.user) return -1;
+                            if (a.user < b.user) return 1;
+                            return 0;
+                        }
+                        else {
+                            if (a.user < b.user) return -1;
+                            if (a.user > b.user) return 1;
+                            return 0;
+                        }
+                    case "CPU":
+                        if (ascending) return a.pcpu - b.pcpu;
+                        else return b.pcpu - a.pcpu;
+                    case "Memory":
+                        if (ascending) return a.pmem - b.pmem;
+                        else return b.pmem - a.pmem;
+                    case "State":
+                        if (a.state < b.state) return -1;
+                        if (a.state > b.state) return 1;
+                        return 0;
+                    case "Started":
+                        if (ascending) return Date.parse(a.started) - Date.parse(b.started);
+                        else return Date.parse(b.started) - Date.parse(a.started);
+                    case "Runtime":
+                        if (ascending) return a.runtime - b.runtime;
+                        else return b.runtime - a.runtime;
+                    default:
+                        // default to the same sorting as the toplist
+                        return ((b.pcpu-a.pcpu)*100 + b.pmem-a.pmem);
+                    }
+                });
 
                 document.querySelectorAll("#processList > tr").forEach(el => {
                     el.remove();
                 });
 
                 list.forEach(proc => {
-                    let runtime = new Date(Date.now() - Date.parse(proc.started));
                     let el = document.createElement("tr");
                     el.innerHTML = `<td class="pid">${proc.pid}</td>
                                 <td class="name">${proc.name}</td>
@@ -86,7 +168,7 @@ class Toplist {
                                 <td class="mem">${Math.round(proc.pmem*10)/10}%</td>
                                 <td class="state">${proc.state}</td>
                                 <td class="started">${proc.started}</td>
-                                <td class="runtime">${runtime.getHours()}:${runtime.getMinutes()}:${runtime.getSeconds()}</td>`;
+                                <td class="runtime">${formatRuntime(proc.runtime)}</td>`;
                     document.getElementById("processList").append(el);
                 });
             });
@@ -116,10 +198,23 @@ class Toplist {
     </table>`,
             }
         );
+
+        let headers = document.getElementsByClassName("header");
+        for (let header of headers){
+            let title = header.textContent;
+            header.addEventListener("click", () => {
+                for (let header of headers) {
+                    header.textContent = header.textContent.replace('\u25B2', "").replace('\u25BC', "");
+                }
+                setSortKey(title);
+                header.textContent = `${title}${ascending ? '\u25B2' : '\u25BC'}`;
+            });
+        }
+
         updateProcessList();
         window.keyboard.attach();
         window.term[window.currentTerm].term.focus();
-        setInterval(updateProcessList, 2000);
+        setInterval(updateProcessList, 1000);
     }
 }
 

--- a/src/classes/toplist.class.js
+++ b/src/classes/toplist.class.js
@@ -52,14 +52,18 @@ class Toplist {
     }
 
     processList(){
-<<<<<<< HEAD
-=======
-        let sortKey = "runtime";
+        let sortKey;
         let ascending = false;
 
         function setSortKey(fieldName){
             if (sortKey === fieldName){
-                ascending = !ascending;
+                if (ascending){
+                    sortKey = undefined;
+                    ascending = false;
+                }
+                else{
+                    ascending = true;
+                }
             }
             else {
                 sortKey = fieldName;
@@ -85,7 +89,6 @@ class Toplist {
             return `${days < 10 ? "0" : ""}${days}:${hours < 10 ? "0" : ""}${hours}:${minutes < 10 ? "0" : ""}${minutes}:${seconds < 10 ? "0" : ""}${seconds}`;
         }
 
->>>>>>> ab1d3b29ae818a2450f52994d0a2288d2e1eb473
         function updateProcessList(){
             window.si.processes().then(data => {
                 if (window.settings.excludeThreadsFromToplist === true) {
@@ -195,7 +198,7 @@ class Toplist {
     </thead>
     <tbody id=\"processList\">
     </tbody>
-    </table>`,
+  </table>`,
             }
         );
 
@@ -207,7 +210,9 @@ class Toplist {
                     header.textContent = header.textContent.replace('\u25B2', "").replace('\u25BC', "");
                 }
                 setSortKey(title);
-                header.textContent = `${title}${ascending ? '\u25B2' : '\u25BC'}`;
+                if (sortKey){
+                    header.textContent = `${title}${ascending ? '\u25B2' : '\u25BC'}`;
+                }
             });
         }
 


### PR DESCRIPTION
Wish I had thought of this before you merged the other PR. But I added the ability to control how the process list modal sorts processes. It defaults to the same method as the toplist, but clicking on a column in the table header will now make it sort the processes by the value in that column.