### PR TITLE
Starting on non windows fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,13 @@
   <br><br><br>
 </p>
 
-
 eDEX-UI is a fullscreen, cross-platform terminal emulator and system monitor that looks and feels like a sci-fi computer interface.
 
-Heavily inspired from the [TRON Legacy movie effects](https://web.archive.org/web/20170511000410/http://jtnimoy.com/blogs/projects/14881671) (especially the [Board Room sequence](https://gmunk.com/TRON-Board-Room)), the eDEX-UI project was originally meant to be *"[DEX-UI](https://github.com/seenaburns/dex-ui) with less « art » and more « distributable software »"*. While keeping a futuristic look and feel, it strives to maintain a certain level of functionality and to be usable in real-life scenarios, with the larger goal of bringing science-fiction UXs to the mainstream.
+Heavily inspired from the [TRON Legacy movie effects](https://web.archive.org/web/20170511000410/http://jtnimoy.com/blogs/projects/14881671) (especially the [Board Room sequence](https://gmunk.com/TRON-Board-Room)), the eDEX-UI project was originally meant to be _"[DEX-UI](https://github.com/seenaburns/dex-ui) with less « art » and more « distributable software »"_. While keeping a futuristic look and feel, it strives to maintain a certain level of functionality and to be usable in real-life scenarios, with the larger goal of bringing science-fiction UXs to the mainstream.
 
 It might or might not be a joke taken too seriously.
 
-*( Jump to: [Screenshots](#screenshots) - [Questions & Answers](#qa) - **[Download](#how-do-i-get-it)** - [Featured In](#featured-in) - [Developer Instructions](#useful-commands-for-the-nerds) - [Credits](#credits) )*
+_( Jump to: [Screenshots](#screenshots) - [Questions & Answers](#qa) - **[Download](#how-do-i-get-it)** - [Featured In](#featured-in) - [Developer Instructions](#useful-commands-for-the-nerds) - [Credits](#credits) )_
 
 ## Sponsor
 
@@ -34,6 +33,7 @@ Click the banner below and sign up to **Bytes**, the only newsletter cool enough
 [![Bytes by UI.dev](https://github.com/GitSquared/edex-ui/raw/master/media/sponsor-uidev-bytes.jpg)](https://ui.dev/bytes/?r=gabriel)
 
 ## Features
+
 - Fully featured terminal emulator with tabs, colors, mouse events, and support for `curses` and `curses`-like applications.
 - Real-time system (CPU, RAM, swap, processes) and network (GeoIP, active connections, transfer rates) monitoring.
 - Full support for touch-enabled displays, including an on-screen keyboard.
@@ -42,6 +42,7 @@ Click the banner below and sign up to **Bytes**, the only newsletter cool enough
 - Optional sound effects made by a talented sound designer for maximum hollywood hacking vibe.
 
 ## Screenshots
+
 ![Default screenshot](https://github.com/GitSquared/edex-ui/raw/master/media/screenshot_default.png)
 
 _([neofetch](https://github.com/dylanaraps/neofetch) on eDEX-UI 2.2 with the default "tron" theme & QWERTY keyboard)_
@@ -55,30 +56,46 @@ _(Graphical settings editor and list of keyboard shortcuts on eDEX-UI 2.2 with t
 _([cmatrix](https://github.com/abishekvashok/cmatrix) on eDEX-UI 2.2 with the experimental "tron-disrupted" theme, and the user-contributed DVORAK keyboard)_
 
 ## Q&A
+
 #### How do I get it?
+
 Click on the little badges under the eDEX logo at the top of this page, or go to the [Releases](https://github.com/GitSquared/edex-ui/releases) tab, or download it through [one of the available repositories](https://repology.org/project/edex-ui/versions) (Homebrew, AUR...).
 
 Public release binaries are unsigned ([why](https://gaby.dev/posts/code-signing)). On Linux, you will need to `chmod +x` the AppImage file in order to run it.
+
 #### I have a problem!
+
 Search through the [Issues](https://github.com/GitSquared/edex-ui/issues) to see if yours has already been reported. If you're confident it hasn't been reported yet, feel free to open up a new one. If you see your issue and it's been closed, it probably means that the fix for it will ship in the next version, and you'll have to wait a bit.
+
 #### Can you disable the keyboard/the filesystem display?
+
 You can't disable them (yet) but you can hide them. See the `tron-notype` theme.
+
 #### Why is the file browser saying that "Tracking Failed"? (Windows only)
+
 On Linux and macOS, eDEX tracks where you're going in your terminal tab to display the content of the current folder on-screen.
 Sadly, this is technically impossible to do on Windows right now, so the file browser reverts back to a "detached" mode. You can still use it to browse files & directories and click on files to input their path in the terminal.
+
 #### Can this run on a Raspberry Pi / ARM device?
+
 We provide prebuilt arm64 builds. For other platforms, see [this issue comment](https://github.com/GitSquared/edex-ui/issues/313#issuecomment-443465345), and the thread on issue [#818](https://github.com/GitSquared/edex-ui/issues/818).
+
 #### Is this repo actively maintained?
+
 [See this notice](https://github.com/GitSquared/edex-ui/issues/769)
+
 #### How did you make this?
+
 Glad you're interested! See [#272](https://github.com/GitSquared/edex-ui/issues/272).
+
 #### This is so cool.
+
 Thanks! If you feel like it, you can [buy me a coffee](https://buymeacoff.ee/gaby) or [sponsor me on GitHub](https://github.com/sponsors/GitSquared) to encourage me to build more awesome stuff.
 
 <img width="220" src="https://78.media.tumblr.com/35d4ef4447e0112f776b629bffd99188/tumblr_mk4gf8zvyC1s567uwo1_500.gif" />
 
-
 ## Featured in...
+
 - [Linux Uprising Blog](https://www.linuxuprising.com/2018/11/edex-ui-fully-functioning-sci-fi.html)
 - [My post on r/unixporn](https://www.reddit.com/r/unixporn/comments/9ysbx7/oc_a_little_project_that_ive_been_working_on/)
 - [Korben article (in french)](https://korben.info/une-interface-futuriste-pour-vos-ecrans-tactiles.html)
@@ -94,24 +111,27 @@ Thanks! If you feel like it, you can [buy me a coffee](https://buymeacoff.ee/gab
 - [LinuxLinks](https://www.linuxlinks.com/linux-candy-edex-ui-sci-fi-computer-terminal-emulator-system-monitor/)
 - [Linux For Everyone (Youtube)](https://www.youtube.com/watch?v=gbzqCAjm--g)
 
-
 ## Useful commands for the nerds
 
 **IMPORTANT NOTE:** the following instructions are meant for running eDEX from the latest unoptimized, unreleased, development version. If you'd like to get stable software instead, refer to [these](#how-do-i-get-it) instructions.
 
 #### Starting from source:
-on *nix systems (You'll need the Xcode command line tools on macOS):
+
+on \*nix systems (You'll need the Xcode command line tools on macOS):
+
 - clone the repository
 - `npm run install-linux`
-- `npm run start-linux`
+- `npm run start`
 
 on Windows:
+
 - start cmd or powershell **as administrator**
 - clone the repository
 - `npm run install-windows`
-- `npm run start-windows`
+- `npm run start`
 
 #### Building
+
 Note: Due to native modules, you can only build targets for the host OS you are using.
 
 - `npm install` (NOT `install-linux` or `install-windows`)
@@ -120,9 +140,11 @@ Note: Due to native modules, you can only build targets for the host OS you are 
 The script will minify the source code, recompile native dependencies and create distributable assets in the `dist` folder.
 
 #### Getting the bleeding edge
+
 If you're interested in running the latest in-development version but don't want to compile source code yourself, you can can get pre-built nightly binaries on [GitHub Actions](https://github.com/GitSquared/edex-ui/actions): click the latest commits, and download the artifacts bundle for your OS.
 
 ## Credits
+
 eDEX-UI's source code was primarily written by me, [Squared](https://github.com/GitSquared). If you want to get in touch with me or find other projects I'm involved in, check out [my website](https://gaby.dev).
 
 [PixelyIon](https://github.com/PixelyIon) helped me get started with Windows compatibility and offered some precious advice when I started to work on this project seriously.
@@ -130,6 +152,7 @@ eDEX-UI's source code was primarily written by me, [Squared](https://github.com/
 [IceWolf](https://soundcloud.com/iamicewolf) composed the sound effects on v2.1.x and above. He makes really cool stuff, check out his music!
 
 ## Thanks
+
 Of course, eDEX would never have existed if I hadn't stumbled upon the amazing work of [Seena](https://github.com/seenaburns) on [r/unixporn](https://reddit.com/r/unixporn).
 
 This project uses a bunch of open-source libraries, frameworks and tools, see [the full dependency graph](https://github.com/GitSquared/edex-ui/network/dependencies).

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ Thanks! If you feel like it, you can [buy me a coffee](https://buymeacoff.ee/gab
 on *nix systems (You'll need the Xcode command line tools on macOS):
 - clone the repository
 - `npm run install-linux`
-- `npm start`
+- `npm run start-linux`
 
 on Windows:
 - start cmd or powershell **as administrator**
 - clone the repository
 - `npm run install-windows`
-- `npm start`
+- `npm run start-windows`
 
 #### Building
 Note: Due to native modules, you can only build targets for the host OS you are using.

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@
   <br><br><br>
 </p>
 
+
 eDEX-UI is a fullscreen, cross-platform terminal emulator and system monitor that looks and feels like a sci-fi computer interface.
 
-Heavily inspired from the [TRON Legacy movie effects](https://web.archive.org/web/20170511000410/http://jtnimoy.com/blogs/projects/14881671) (especially the [Board Room sequence](https://gmunk.com/TRON-Board-Room)), the eDEX-UI project was originally meant to be _"[DEX-UI](https://github.com/seenaburns/dex-ui) with less « art » and more « distributable software »"_. While keeping a futuristic look and feel, it strives to maintain a certain level of functionality and to be usable in real-life scenarios, with the larger goal of bringing science-fiction UXs to the mainstream.
+Heavily inspired from the [TRON Legacy movie effects](https://web.archive.org/web/20170511000410/http://jtnimoy.com/blogs/projects/14881671) (especially the [Board Room sequence](https://gmunk.com/TRON-Board-Room)), the eDEX-UI project was originally meant to be *"[DEX-UI](https://github.com/seenaburns/dex-ui) with less « art » and more « distributable software »"*. While keeping a futuristic look and feel, it strives to maintain a certain level of functionality and to be usable in real-life scenarios, with the larger goal of bringing science-fiction UXs to the mainstream.
 
 It might or might not be a joke taken too seriously.
 
-_( Jump to: [Screenshots](#screenshots) - [Questions & Answers](#qa) - **[Download](#how-do-i-get-it)** - [Featured In](#featured-in) - [Developer Instructions](#useful-commands-for-the-nerds) - [Credits](#credits) )_
+*( Jump to: [Screenshots](#screenshots) - [Questions & Answers](#qa) - **[Download](#how-do-i-get-it)** - [Featured In](#featured-in) - [Developer Instructions](#useful-commands-for-the-nerds) - [Credits](#credits) )*
 
 ## Sponsor
 
@@ -33,7 +34,6 @@ Click the banner below and sign up to **Bytes**, the only newsletter cool enough
 [![Bytes by UI.dev](https://github.com/GitSquared/edex-ui/raw/master/media/sponsor-uidev-bytes.jpg)](https://ui.dev/bytes/?r=gabriel)
 
 ## Features
-
 - Fully featured terminal emulator with tabs, colors, mouse events, and support for `curses` and `curses`-like applications.
 - Real-time system (CPU, RAM, swap, processes) and network (GeoIP, active connections, transfer rates) monitoring.
 - Full support for touch-enabled displays, including an on-screen keyboard.
@@ -42,7 +42,6 @@ Click the banner below and sign up to **Bytes**, the only newsletter cool enough
 - Optional sound effects made by a talented sound designer for maximum hollywood hacking vibe.
 
 ## Screenshots
-
 ![Default screenshot](https://github.com/GitSquared/edex-ui/raw/master/media/screenshot_default.png)
 
 _([neofetch](https://github.com/dylanaraps/neofetch) on eDEX-UI 2.2 with the default "tron" theme & QWERTY keyboard)_
@@ -56,46 +55,30 @@ _(Graphical settings editor and list of keyboard shortcuts on eDEX-UI 2.2 with t
 _([cmatrix](https://github.com/abishekvashok/cmatrix) on eDEX-UI 2.2 with the experimental "tron-disrupted" theme, and the user-contributed DVORAK keyboard)_
 
 ## Q&A
-
 #### How do I get it?
-
 Click on the little badges under the eDEX logo at the top of this page, or go to the [Releases](https://github.com/GitSquared/edex-ui/releases) tab, or download it through [one of the available repositories](https://repology.org/project/edex-ui/versions) (Homebrew, AUR...).
 
 Public release binaries are unsigned ([why](https://gaby.dev/posts/code-signing)). On Linux, you will need to `chmod +x` the AppImage file in order to run it.
-
 #### I have a problem!
-
 Search through the [Issues](https://github.com/GitSquared/edex-ui/issues) to see if yours has already been reported. If you're confident it hasn't been reported yet, feel free to open up a new one. If you see your issue and it's been closed, it probably means that the fix for it will ship in the next version, and you'll have to wait a bit.
-
 #### Can you disable the keyboard/the filesystem display?
-
 You can't disable them (yet) but you can hide them. See the `tron-notype` theme.
-
 #### Why is the file browser saying that "Tracking Failed"? (Windows only)
-
 On Linux and macOS, eDEX tracks where you're going in your terminal tab to display the content of the current folder on-screen.
 Sadly, this is technically impossible to do on Windows right now, so the file browser reverts back to a "detached" mode. You can still use it to browse files & directories and click on files to input their path in the terminal.
-
 #### Can this run on a Raspberry Pi / ARM device?
-
 We provide prebuilt arm64 builds. For other platforms, see [this issue comment](https://github.com/GitSquared/edex-ui/issues/313#issuecomment-443465345), and the thread on issue [#818](https://github.com/GitSquared/edex-ui/issues/818).
-
 #### Is this repo actively maintained?
-
 [See this notice](https://github.com/GitSquared/edex-ui/issues/769)
-
 #### How did you make this?
-
 Glad you're interested! See [#272](https://github.com/GitSquared/edex-ui/issues/272).
-
 #### This is so cool.
-
 Thanks! If you feel like it, you can [buy me a coffee](https://buymeacoff.ee/gaby) or [sponsor me on GitHub](https://github.com/sponsors/GitSquared) to encourage me to build more awesome stuff.
 
 <img width="220" src="https://78.media.tumblr.com/35d4ef4447e0112f776b629bffd99188/tumblr_mk4gf8zvyC1s567uwo1_500.gif" />
 
-## Featured in...
 
+## Featured in...
 - [Linux Uprising Blog](https://www.linuxuprising.com/2018/11/edex-ui-fully-functioning-sci-fi.html)
 - [My post on r/unixporn](https://www.reddit.com/r/unixporn/comments/9ysbx7/oc_a_little_project_that_ive_been_working_on/)
 - [Korben article (in french)](https://korben.info/une-interface-futuriste-pour-vos-ecrans-tactiles.html)
@@ -111,27 +94,24 @@ Thanks! If you feel like it, you can [buy me a coffee](https://buymeacoff.ee/gab
 - [LinuxLinks](https://www.linuxlinks.com/linux-candy-edex-ui-sci-fi-computer-terminal-emulator-system-monitor/)
 - [Linux For Everyone (Youtube)](https://www.youtube.com/watch?v=gbzqCAjm--g)
 
+
 ## Useful commands for the nerds
 
 **IMPORTANT NOTE:** the following instructions are meant for running eDEX from the latest unoptimized, unreleased, development version. If you'd like to get stable software instead, refer to [these](#how-do-i-get-it) instructions.
 
 #### Starting from source:
-
-on \*nix systems (You'll need the Xcode command line tools on macOS):
-
+on *nix systems (You'll need the Xcode command line tools on macOS):
 - clone the repository
 - `npm run install-linux`
 - `npm run start`
 
 on Windows:
-
 - start cmd or powershell **as administrator**
 - clone the repository
 - `npm run install-windows`
 - `npm run start`
 
 #### Building
-
 Note: Due to native modules, you can only build targets for the host OS you are using.
 
 - `npm install` (NOT `install-linux` or `install-windows`)
@@ -140,11 +120,9 @@ Note: Due to native modules, you can only build targets for the host OS you are 
 The script will minify the source code, recompile native dependencies and create distributable assets in the `dist` folder.
 
 #### Getting the bleeding edge
-
 If you're interested in running the latest in-development version but don't want to compile source code yourself, you can can get pre-built nightly binaries on [GitHub Actions](https://github.com/GitSquared/edex-ui/actions): click the latest commits, and download the artifacts bundle for your OS.
 
 ## Credits
-
 eDEX-UI's source code was primarily written by me, [Squared](https://github.com/GitSquared). If you want to get in touch with me or find other projects I'm involved in, check out [my website](https://gaby.dev).
 
 [PixelyIon](https://github.com/PixelyIon) helped me get started with Windows compatibility and offered some precious advice when I started to work on this project seriously.
@@ -152,7 +130,6 @@ eDEX-UI's source code was primarily written by me, [Squared](https://github.com/
 [IceWolf](https://soundcloud.com/iamicewolf) composed the sound effects on v2.1.x and above. He makes really cool stuff, check out his music!
 
 ## Thanks
-
 Of course, eDEX would never have existed if I hadn't stumbled upon the amazing work of [Seena](https://github.com/seenaburns) on [r/unixporn](https://reddit.com/r/unixporn).
 
 This project uses a bunch of open-source libraries, frameworks and tools, see [the full dependency graph](https://github.com/GitSquared/edex-ui/network/dependencies).

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   ],
   "main": "src/_boot.js",
   "scripts": {
-    "start": "node_modules\\.bin\\electron src --nointro",
+    "start-windows": "node_modules\\.bin\\electron src --nointro",
+    "start-linux": "node_modules/.bin/electron src --nointro",
     "install-linux": "npm install && cd src && npm install && ./../node_modules/.bin/electron-rebuild -f -w node-pty && cd ..",
     "preinstall-windows": "npm install --global --production windows-build-tools && npm install --global node-gyp && setx PYTHON \"%USERPROFILE%\\.windows-build-tools\\python27\\python.exe\"",
     "install-windows": "npm install && cd src && npm install && ..\\node_modules\\.bin\\electron-rebuild -f -w node-pty && cd ..",
@@ -107,6 +108,7 @@
   },
   "dependencies": {
     "clean-css": "4.2.3",
+    "cson-parser": "4.0.7",
     "electron": "^10.1.6",
     "electron-builder": "^22.9.1",
     "electron-rebuild": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   ],
   "main": "src/_boot.js",
   "scripts": {
-    "start-windows": "node_modules\\.bin\\electron src --nointro",
-    "start-linux": "node_modules/.bin/electron src --nointro",
+    "start": "electron src --nointro",
     "install-linux": "npm install && cd src && npm install && ./../node_modules/.bin/electron-rebuild -f -w node-pty && cd ..",
     "preinstall-windows": "npm install --global --production windows-build-tools && npm install --global node-gyp && setx PYTHON \"%USERPROFILE%\\.windows-build-tools\\python27\\python.exe\"",
     "install-windows": "npm install && cd src && npm install && ..\\node_modules\\.bin\\electron-rebuild -f -w node-pty && cd ..",
@@ -108,7 +107,6 @@
   },
   "dependencies": {
     "clean-css": "4.2.3",
-    "cson-parser": "4.0.7",
     "electron": "^10.1.6",
     "electron-builder": "^22.9.1",
     "electron-rebuild": "^2.3.2",

--- a/src/package.json
+++ b/src/package.json
@@ -30,7 +30,6 @@
     "maxmind": "4.3.1",
     "nanoid": "3.1.20",
     "node-pty": "0.9.0",
-    "osx-temperature-sensor": "1.0.7",
     "pretty-bytes": "5.4.1",
     "shell-env": "3.0.0",
     "signale": "1.4.0",

--- a/src/package.json
+++ b/src/package.json
@@ -30,6 +30,7 @@
     "maxmind": "4.3.1",
     "nanoid": "3.1.20",
     "node-pty": "0.9.0",
+    "osx-temperature-sensor": "1.0.7",
     "pretty-bytes": "5.4.1",
     "shell-env": "3.0.0",
     "signale": "1.4.0",


### PR DESCRIPTION
Hey I recently ran into some issues starting the project on mac: 

```
npm run start                               

> edex-ui@3.0.0-pre start
> node_modules\.bin\electron src --nointro

sh: node_modules.binelectron: command not found
npm ERR! code 127
```
 I was able to find a work around when I updated the file pathing in the `package.json` to not include back slashes. I tested the start command on a windows machine and the current master version worked fine, so I broke out the commands to be seperate depending on the file path conventions and updated the README to include them both. 

I notice that the build steps take a similar approach as the one I've provided, let me know if there is anything else we need to get this merged. ! 

 