### PR TITLE
fix: 'forceFullscreen' being overwritten by settings GUI

### DIFF
--- a/src/_renderer.js
+++ b/src/_renderer.js
@@ -839,6 +839,7 @@ window.writeSettingsFile = () => {
         nocursor: (document.getElementById("settingsEditor-nocursor").value === "true"),
         iface: document.getElementById("settingsEditor-iface").value,
         allowWindowed: (document.getElementById("settingsEditor-allowWindowed").value === "true"),
+        forceFullscreen: window.settings.forceFullscreen,
         keepGeometry: (document.getElementById("settingsEditor-keepGeometry").value === "true"),
         excludeThreadsFromToplist: (document.getElementById("settingsEditor-excludeThreadsFromToplist").value === "true"),
         hideDotfiles: (document.getElementById("settingsEditor-hideDotfiles").value === "true"),


### PR DESCRIPTION
Fixes an issue where the `forceFullscreen` setting would be removed whenever the settings file was modified by the GUI settings editor.